### PR TITLE
Change teamleader.eu urls to focus.teamleader.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $expiresAt = $teamleader->getTokenExpiresAt();
 
 ## Available methods
 
-Note that your application should have the correct scopes enabled inside the [integration](https://marketplace.teamleader.eu/be/nl/ontwikkel/integraties)
+Note that your application should have the correct scopes enabled inside the [integration](https://marketplace.focus.teamleader.eu/be/nl/ontwikkel/integraties)
 
 This application is in an early development stage. Therefore not all resources are available as props yet. (for example: `$teamleader->users->me`)
 In the meantime it's possible to fetch every resource available through the `get` and `post` methods:

--- a/src/Teamleader.php
+++ b/src/Teamleader.php
@@ -20,7 +20,7 @@ class Teamleader
     /**
      * @var string
      */
-    private $baseUrl = 'https://app.teamleader.eu';
+    private $baseUrl = 'https://focus.teamleader.eu';
 
     /**
      * @var string
@@ -234,7 +234,7 @@ class Teamleader
 
     private function buildUrl(string $endpoint): string
     {
-        return 'https://api.teamleader.eu/' . ltrim($endpoint, '/');
+        return 'https://api.focus.teamleader.eu/' . ltrim($endpoint, '/');
     }
 
     private function parseResponse(Response $response)


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.